### PR TITLE
CHORE upgrades GitHub action packages to fix Node.js 20 deprecation w…

### DIFF
--- a/.github/actions/create-lines-of-code-report/action.yaml
+++ b/.github/actions/create-lines-of-code-report/action.yaml
@@ -32,7 +32,7 @@ runs:
       run: zip lines-of-code-report.json.zip lines-of-code-report.json
     - name: "Upload CLOC report as an artefact"
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: lines-of-code-report.json.zip
         path: ./lines-of-code-report.json.zip
@@ -44,7 +44,7 @@ runs:
 #        echo "secrets_exist=${{ inputs.idp_aws_report_upload_role_name != '' && inputs.idp_aws_report_upload_bucket_endpoint != '' }}" >> $GITHUB_OUTPUT
 #    - name: "Authenticate to send the report"
 #      if: steps.check.outputs.secrets_exist == 'true'
-#      uses: aws-actions/configure-aws-credentials@v2
+#      uses: aws-actions/configure-aws-credentials@v6
 #      with:
 #        role-to-assume: arn:aws:iam::${{ inputs.idp_aws_report_upload_account_id }}:role/${{ inputs.idp_aws_report_upload_role_name }}
 #        aws-region: ${{ inputs.idp_aws_report_upload_region }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -28,7 +28,7 @@ runs:
         path: "code-for-app"
 
     - name: "Configure AWS credentials"
-      uses: aws-actions/configure-aws-credentials@v5
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-session-name: GitHubActionsSession
         role-to-assume: ${{ inputs.secret_aws_iam_role }}
@@ -46,7 +46,7 @@ runs:
         echo "terraform_version=$(grep "^terraform" .tool-versions | cut -f2 -d' ')" >> $GITHUB_OUTPUT
 
     - name: "Install Terraform version"
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: "${{ steps.identify-terraform-version.outputs.terraform_version }}"
 

--- a/.github/actions/lint-terraform/action.yaml
+++ b/.github/actions/lint-terraform/action.yaml
@@ -19,7 +19,7 @@ runs:
         echo "terraform_version=$(grep "^terraform" .tool-versions | cut -f2 -d' ')" >> $GITHUB_OUTPUT
 
     - name: "Install Terraform"
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: "${{ steps.identify-terraform-version.outputs.terraform_version }}"
 

--- a/.github/actions/run-contract-tests/action.yml
+++ b/.github/actions/run-contract-tests/action.yml
@@ -31,7 +31,7 @@ runs:
         node-version: ${{ steps.variables.outputs.nodejs_version }}
 
     - name: "Cache node modules"
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-node-modules
       with:

--- a/.github/actions/run-e2e-tests/action.yaml
+++ b/.github/actions/run-e2e-tests/action.yaml
@@ -32,7 +32,7 @@ runs:
 
     - name: Cache node modules
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-node-modules
       with:
@@ -62,7 +62,7 @@ runs:
         exit $EXIT_STATUS
 
     - name: Cache Playwright browsers
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
@@ -109,7 +109,7 @@ runs:
         exit $EXIT_STATUS
 
     - name: Upload report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: playwright-report-e2e-${{ inputs.checkout_ref }}

--- a/.github/actions/run-nbs-e2e-tests/action.yaml
+++ b/.github/actions/run-nbs-e2e-tests/action.yaml
@@ -29,7 +29,7 @@ runs:
 
     - name: Cache node modules
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-node-modules
       with:
@@ -59,7 +59,7 @@ runs:
         exit $EXIT_STATUS
 
     - name: Cache Playwright browsers
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
@@ -94,7 +94,7 @@ runs:
         npm run e2e:nbs
 
     - name: Upload report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: playwright-report-nbs-e2e-${{ inputs.checkout_ref }}

--- a/.github/actions/run-snapshot-tests/action.yaml
+++ b/.github/actions/run-snapshot-tests/action.yaml
@@ -31,7 +31,7 @@ runs:
         node-version: ${{ steps.variables.outputs.nodejs_version }}
 
     - name: "Configure AWS credentials"
-      uses: aws-actions/configure-aws-credentials@v5
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-session-name: GitHubActionsSession
         role-to-assume: ${{ env.SECRET_IAM_ROLE }}
@@ -39,7 +39,7 @@ runs:
 
     - name: "Cache node modules"
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: cache-node-modules
       with:
@@ -76,7 +76,7 @@ runs:
         echo "::endgroup::"
 
     - name: "Cache Playwright browsers"
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
@@ -126,7 +126,7 @@ runs:
         aws s3 sync --delete ./e2e/snapshot/snapshot_review/ s3://${{ env.AWS_S3_ARTEFACTS_BUCKET }}/playwright/snapshots-for-review/${{ inputs.release_name }}/${{ steps.folder_name_value.outputs.current_datetime }}-${{ inputs.checkout_ref }}/
 
     - name: "Upload report"
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: playwright-report-snapshot-${{ inputs.release_name }}-${{ steps.folder_name_value.outputs.current_datetime }}-${{ inputs.checkout_ref }}

--- a/.github/actions/scan-dependencies/action.yaml
+++ b/.github/actions/scan-dependencies/action.yaml
@@ -32,7 +32,7 @@ runs:
       run: zip sbom-repository-report.json.zip sbom-repository-report.json
     - name: "Upload SBOM report as an artefact"
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sbom-repository-report.json.zip
         path: ./sbom-repository-report.json.zip
@@ -47,7 +47,7 @@ runs:
       run: zip vulnerabilities-repository-report.json.zip vulnerabilities-repository-report.json
     - name: "Upload vulnerabilities report as an artefact"
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: vulnerabilities-repository-report.json.zip
         path: ./vulnerabilities-repository-report.json.zip
@@ -58,7 +58,7 @@ runs:
 #      run: echo "secrets_exist=${{ inputs.idp_aws_report_upload_role_name != '' && inputs.idp_aws_report_upload_bucket_endpoint != '' }}" >> $GITHUB_OUTPUT
 #    - name: "Authenticate to send the reports"
 #      if: steps.check.outputs.secrets_exist == 'true'
-#      uses: aws-actions/configure-aws-credentials@v2
+#      uses: aws-actions/configure-aws-credentials@v6
 #      with:
 #        role-to-assume: arn:aws:iam::${{ inputs.idp_aws_report_upload_account_id }}:role/${{ inputs.idp_aws_report_upload_role_name }}
 #        aws-region: ${{ inputs.idp_aws_report_upload_region }}


### PR DESCRIPTION
Attempting to fix Node.js 20 warning in all our builds coming from these packages:

- actions/upload-artifact
- aws-actions/configure-aws-credentials
- hashicorp/setup-terraform
- actions/cache

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
