### PR TITLE
VIA-933 TS Log URL for all NextAuth auth endpoints, add nextUrl to logging context and log details of OAuthCallbackErrors

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,14 +1,11 @@
 # This file is for you! Please, updated to the versions agreed by your team.
-
 terraform 1.14.1
 pre-commit 4.5.0
 vale 3.13.0
 nodejs 24.14.0
 gitleaks 8.30.1
-
 # ==============================================================================
 # The section below is reserved for Docker image versions.
-
 # TODO: Move this section - consider using a different file for the repository template dependencies.
 # docker/ghcr.io/anchore/grype v0.106.0@sha256:f6fa9ac31f97591957edb13b7c7c24fd172cf11b6e2a2df5dd3464ebb8eefefc # SEE: https://github.com/anchore/grype/pkgs/container/grype
 # docker/ghcr.io/anchore/syft v1.41.0@sha256:046f0c3b14e4451a1d0cd2f367ce3ba3bd653cbd23a7749556f46592d0281a0d # SEE: https://github.com/anchore/syft/pkgs/container/syft

--- a/auth.ts
+++ b/auth.ts
@@ -9,14 +9,9 @@ import { MaxAgeInSeconds } from "@src/utils/auth/types";
 import config from "@src/utils/config";
 import { logger } from "@src/utils/logger";
 import { profilePerformanceEnd, profilePerformanceStart } from "@src/utils/performance";
-import { RequestContext, asyncLocalStorage } from "@src/utils/requestContext";
-import {
-  extractRequestContextFromHeadersAndCookies,
-  requestScopedStorageWrapper,
-} from "@src/utils/requestScopedStorageWrapper";
 import NextAuth from "next-auth";
 import "next-auth/jwt";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 
 const log = logger.child({ module: "auth" });
 
@@ -24,136 +19,131 @@ const AuthSignInPerformanceMarker = "auth-sign-in-callback";
 const AuthJWTPerformanceMarker = "auth-jwt-callback";
 const AuthSessionPerformanceMarker = "auth-session-callback";
 
+/**
+ * When calling any Auth function (e.g. auth(), signIn(), signOut())
+ * NextAuth will invoke the relevant callback (e.g. jwt(), session(), signIn() etc)
+ * defined in this file.
+ *
+ * In order for logging and performance profiling to work correctly within those callbacks,
+ * we need to ensure that the asyncLocalStorage request context is properly propagated to them.
+ */
 export const { handlers, signIn, signOut, auth } = NextAuth(async () => {
   const MAX_SESSION_AGE_SECONDS: number = (await config.MAX_SESSION_AGE_MINUTES) * 60;
-  const headerValues = await headers();
   const requestCookies = await cookies();
-
-  const requestContext: RequestContext = extractRequestContextFromHeadersAndCookies(headerValues, requestCookies);
 
   function getHasCookies() {
     return {
       hasState: requestCookies.has("__Secure-authjs.state"),
+      hasNonce: requestCookies.has("__Secure-authjs.nonce"),
       hasSessionToken: requestCookies.has("__Secure-authjs.session-token"),
       hasCSRFToken: requestCookies.has("__Host-authjs.csrf-token"),
       hasSessionId: requestCookies.has("__Host-Http-session-id"),
     };
   }
 
-  return await asyncLocalStorage.run(requestContext, async () => {
-    return {
-      providers: [await NHSLoginAuthProvider()],
-      secret: await config.AUTH_SECRET,
-      pages: {
-        signIn: SSO_FAILURE_ROUTE,
-        signOut: SESSION_LOGOUT_ROUTE,
-        error: SSO_FAILURE_ROUTE,
-        verifyRequest: SSO_FAILURE_ROUTE,
-        newUser: SSO_FAILURE_ROUTE,
-      },
-      session: {
-        strategy: "jwt",
-        maxAge: MAX_SESSION_AGE_SECONDS,
-      },
-      debug: process.env.DEPLOY_ENVIRONMENT === "local",
-      trustHost: true,
-      callbacks: {
-        async signIn({ account }) {
-          return await requestScopedStorageWrapper(async () => {
-            log.debug("signIn() callback invoked");
-            let response: boolean;
-            try {
-              profilePerformanceStart(AuthSignInPerformanceMarker);
-              response = await isValidSignIn(account);
-              profilePerformanceEnd(AuthSignInPerformanceMarker);
-            } catch (error) {
-              log.error({ error: error }, "signIn() callback error");
-              response = false;
-            }
+  return {
+    providers: [await NHSLoginAuthProvider()],
+    secret: await config.AUTH_SECRET,
+    pages: {
+      signIn: SSO_FAILURE_ROUTE,
+      signOut: SESSION_LOGOUT_ROUTE,
+      error: SSO_FAILURE_ROUTE,
+      verifyRequest: SSO_FAILURE_ROUTE,
+      newUser: SSO_FAILURE_ROUTE,
+    },
+    session: {
+      strategy: "jwt",
+      maxAge: MAX_SESSION_AGE_SECONDS,
+    },
+    debug: process.env.DEPLOY_ENVIRONMENT === "local",
+    trustHost: true,
+    callbacks: {
+      async signIn({ account }) {
+        log.debug("signIn() callback invoked");
+        let response: boolean;
+        try {
+          profilePerformanceStart(AuthSignInPerformanceMarker);
+          response = await isValidSignIn(account);
+          profilePerformanceEnd(AuthSignInPerformanceMarker);
+        } catch (error) {
+          log.error({ error: error }, "signIn() callback error");
+          response = false;
+        }
 
-            log.info({ context: { isValidSignIn: response } }, "NHS-Login callback");
-            return response;
-          });
-        },
-
-        async jwt({ token, account, profile }) {
-          return await requestScopedStorageWrapper(async () => {
-            log.debug("jwt() callback invoked");
-            let response;
-            try {
-              profilePerformanceStart(AuthJWTPerformanceMarker);
-              response = getToken(token, account, profile, MAX_SESSION_AGE_SECONDS as MaxAgeInSeconds);
-              profilePerformanceEnd(AuthJWTPerformanceMarker);
-            } catch (error) {
-              log.error({ error: error }, "jwt() callback error");
-              response = null;
-            }
-            return response;
-          });
-        },
-
-        async session({ session, token }) {
-          return await requestScopedStorageWrapper(async () => {
-            log.debug("session() callback invoked");
-            let response;
-            try {
-              profilePerformanceStart(AuthSessionPerformanceMarker);
-              response = getUpdatedSession(session, token);
-              log.debug("session() callback fetched session");
-              profilePerformanceEnd(AuthSessionPerformanceMarker);
-            } catch (error) {
-              log.error({ error: error }, "session() callback error");
-              response = { expires: new Date().toISOString() };
-            }
-            return response;
-          });
-        },
+        log.info({ context: { isValidSignIn: response } }, "NHS-Login callback");
+        return response;
       },
-      logger: {
-        error(error: Error) {
-          const hasCookies = getHasCookies();
-          log.error(
-            {
-              error: {
-                cause: error.cause,
-                message: error.message,
-              },
-              context: {
-                cookies: hasCookies,
-              },
-              ...requestContext,
-            },
-            "Error from NextAuth",
-          );
-        },
-        warn(code: WarningCode) {
-          const hasCookies = getHasCookies();
-          log.warn(
-            {
-              context: {
-                code,
-                cookies: hasCookies,
-              },
-              ...requestContext,
-            },
-            "Warning from NextAuth",
-          );
-        },
-        debug(message: string, metadata?) {
-          const hasCookies = getHasCookies();
-          log.debug(
-            {
-              context: {
-                message,
-                metadata,
-                cookies: hasCookies,
-              },
-              ...requestContext,
-            },
-            "Debug from NextAuth",
-          );
-        },
+
+      async jwt({ token, account, profile }) {
+        log.debug("jwt() callback invoked");
+        let response;
+        try {
+          profilePerformanceStart(AuthJWTPerformanceMarker);
+          response = getToken(token, account, profile, MAX_SESSION_AGE_SECONDS as MaxAgeInSeconds);
+          profilePerformanceEnd(AuthJWTPerformanceMarker);
+        } catch (error) {
+          log.error({ error: error }, "jwt() callback error");
+          response = null;
+        }
+        return response;
       },
-    };
-  });
+
+      async session({ session, token }) {
+        log.debug("session() callback invoked");
+        let response;
+        try {
+          profilePerformanceStart(AuthSessionPerformanceMarker);
+          response = getUpdatedSession(session, token);
+          log.debug("session() callback fetched session");
+          profilePerformanceEnd(AuthSessionPerformanceMarker);
+        } catch (error) {
+          log.error({ error: error }, "session() callback error");
+          response = { expires: new Date().toISOString() };
+        }
+        return response;
+      },
+    },
+    logger: {
+      error(error: Error) {
+        const hasCookies = getHasCookies();
+        log.error(
+          {
+            error: {
+              cause: error.cause,
+              message: error.message,
+            },
+            context: {
+              cookies: hasCookies,
+            },
+          },
+          "Error from NextAuth",
+        );
+      },
+      warn(code: WarningCode) {
+        const hasCookies = getHasCookies();
+        log.warn(
+          {
+            context: {
+              code,
+              cookies: hasCookies,
+            },
+          },
+          "Warning from NextAuth",
+        );
+      },
+      debug(message: string, metadata?) {
+        const hasCookies = getHasCookies();
+        log.debug(
+          {
+            context: {
+              message,
+              metadata,
+              cookies: hasCookies,
+            },
+          },
+          "Debug from NextAuth",
+        );
+      },
+    },
+  };
 });

--- a/infrastructure/environments/test/fake-api/nginx.conf
+++ b/infrastructure/environments/test/fake-api/nginx.conf
@@ -46,6 +46,12 @@ server {
         if ($nhs_number = "") {
             set $nhs_number "9686368973";
         }
+
+        set $test_oauth_error $http_x_test_oauth_error;
+        if ($test_oauth_error = "true") {
+            return 302 '$app_root_url/api/auth/callback/nhs-login?error=access_denied&error_description=Simulated+NHS+Login+error&$args';
+        }
+
         return 302 '$app_root_url/api/auth/callback/nhs-login?code=$nhs_number&$args';
     }
 

--- a/infrastructure/environments/test/fake-api/readme.md
+++ b/infrastructure/environments/test/fake-api/readme.md
@@ -67,7 +67,8 @@ If you don't set this header, a random number will be used.
 Start up VitA as normal, then hit [/api/sso](https://localhost:3000/api/sso?assertedLoginIdentity=sausages).
 
 ##### Testing OAuthCallbackError
-To test an OAuthCallbackError within NextAuth set the header `x-test-auth-error=true`. This will simulate an access_denied OAuth Error to the callback url.  
+
+To test an OAuthCallbackError within NextAuth set the header `x-test-auth-error=true`. This will simulate an access_denied OAuth Error to the callback url.
 
 #### Build image for deployment
 

--- a/infrastructure/environments/test/fake-api/readme.md
+++ b/infrastructure/environments/test/fake-api/readme.md
@@ -66,6 +66,9 @@ You can log in as a particular NHS number by setting the header 'x-nhs-number' t
 If you don't set this header, a random number will be used.
 Start up VitA as normal, then hit [/api/sso](https://localhost:3000/api/sso?assertedLoginIdentity=sausages).
 
+##### Testing OAuthCallbackError
+To test an OAuthCallbackError within NextAuth set the header `x-test-auth-error=true`. This will simulate an access_denied OAuth Error to the callback url.  
+
 #### Build image for deployment
 
 For the following steps, you need to have deployed the infrastructure at least once, to get the ALB DNS name.

--- a/scripts/config/vale/styles/config/vocabularies/words/accept.txt
+++ b/scripts/config/vale/styles/config/vocabularies/words/accept.txt
@@ -1,4 +1,3 @@
-[A-Z]+s
 Bitwarden
 bot
 (?i)CLI
@@ -38,3 +37,5 @@ buildx
 vegeta
 jq
 JMeter
+access_denied
+(?i)url

--- a/src/app/api/auth/[...nextauth]/route.test.ts
+++ b/src/app/api/auth/[...nextauth]/route.test.ts
@@ -1,0 +1,143 @@
+import { handlers } from "@project/auth";
+import { extractRequestContextFromHeadersAndCookies } from "@project/src/utils/requestScopedStorageWrapper";
+import { GET } from "@src/app/api/auth/[...nextauth]/route";
+import { logger } from "@src/utils/logger";
+import { NextRequest } from "next/server";
+
+jest.mock("@project/auth", () => ({
+  handlers: {
+    GET: jest.fn(),
+    POST: jest.fn(),
+  },
+}));
+
+jest.mock("@src/app/api/auth/[...nextauth]/provider", () => ({
+  NHS_LOGIN_PROVIDER_ID: "nhs-login",
+}));
+
+jest.mock("@src/utils/logger", () => ({
+  logger: {
+    child: jest.fn().mockReturnValue({
+      error: jest.fn(),
+      info: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("@project/src/utils/requestContext", () => ({
+  asyncLocalStorage: {
+    run: jest.fn().mockImplementation((_ctx: unknown, callback: () => unknown) => callback()),
+  },
+}));
+
+jest.mock("@project/src/utils/requestScopedStorageWrapper");
+
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn().mockImplementation((url: string, init?: RequestInit) => ({
+    url,
+    headers: init?.headers ?? new Headers(),
+  })),
+}));
+
+const buildMockRequest = (pathname: string, params?: Record<string, string>): NextRequest =>
+  ({
+    method: "GET",
+    nextUrl: {
+      pathname,
+      searchParams: new URLSearchParams(params),
+    },
+  }) as unknown as NextRequest;
+
+describe("GET", () => {
+  const mockLogError = (logger.child as jest.Mock).mock.results[0].value.error as jest.Mock;
+  const mockLogInfo = (logger.child as jest.Mock).mock.results[0].value.info as jest.Mock;
+  const mockResponse = { status: 200 } as Response;
+
+  const mockContext = { sessionId: "test-session-id", traceId: "test-trace-id", nextUrl: "" };
+
+  beforeEach(() => {
+    (handlers.GET as jest.Mock).mockResolvedValue(mockResponse);
+    (extractRequestContextFromHeadersAndCookies as jest.Mock).mockReturnValueOnce(mockContext);
+  });
+
+  it("should log the pathname on GET request with correct context", async () => {
+    const req = buildMockRequest("/api/auth/signin") as unknown as NextRequest;
+
+    await GET(req);
+
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      {
+        context: { pathname: "/api/auth/signin" },
+        sessionId: "test-session-id",
+        traceId: "test-trace-id",
+        nextUrl: "/api/auth/signin",
+      },
+      "GET NextAuth route",
+    );
+  });
+
+  it("should delegate to nextAuth handlers.GET with the original request", async () => {
+    const req = buildMockRequest("/api/auth/callback/nhs-login") as unknown as NextRequest;
+
+    await GET(req);
+
+    expect(handlers.GET).toHaveBeenCalledWith(req);
+  });
+
+  describe("when the callback URL contains an OAuth error", () => {
+    it("should log the error and error_description", async () => {
+      const req = buildMockRequest("/api/auth/callback/nhs-login", {
+        error: "access_denied",
+        error_description: "User cancelled login",
+      }) as unknown as NextRequest;
+
+      await GET(req);
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        { error: "access_denied", error_description: "User cancelled login" },
+        "OAuth provider returned error in callback",
+        {
+          sessionId: "test-session-id",
+          traceId: "test-trace-id",
+          nextUrl: "/api/auth/callback/nhs-login",
+        },
+      );
+    });
+
+    it("should log null when error_description is absent", async () => {
+      const req = buildMockRequest("/api/auth/callback/nhs-login", { error: "server_error" }) as unknown as NextRequest;
+
+      await GET(req);
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        { error: "server_error", error_description: null },
+        "OAuth provider returned error in callback",
+        {
+          sessionId: "test-session-id",
+          traceId: "test-trace-id",
+          nextUrl: "/api/auth/callback/nhs-login",
+        },
+      );
+    });
+  });
+
+  describe("when the callback URL has no error", () => {
+    it("should not log an error", async () => {
+      const req = buildMockRequest("/api/auth/callback/nhs-login") as unknown as NextRequest;
+
+      await GET(req);
+
+      expect(mockLogError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the path is not the OAuth callback", () => {
+    it("should not log an error even if an error param is present", async () => {
+      const req = buildMockRequest("/api/auth/signin", { error: "OAuthCallbackError" }) as unknown as NextRequest;
+
+      await GET(req);
+
+      expect(mockLogError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,36 @@
 import { handlers } from "@project/auth";
+import { RequestContext, asyncLocalStorage } from "@project/src/utils/requestContext";
+import { extractRequestContextFromHeadersAndCookies } from "@project/src/utils/requestScopedStorageWrapper";
+import { NHS_LOGIN_PROVIDER_ID } from "@src/app/api/auth/[...nextauth]/provider";
+import { logger } from "@src/utils/logger";
+import { NextRequest } from "next/server";
 
-export const { GET, POST } = handlers;
+const log = logger.child({ module: "auth-route" });
+
+const NHS_LOGIN_CALLBACK_PATH = `/api/auth/callback/${NHS_LOGIN_PROVIDER_ID}`;
+
+export const GET = async (req: NextRequest) => {
+  const { pathname, searchParams } = req.nextUrl;
+
+  const requestContext: RequestContext = extractRequestContextFromHeadersAndCookies(req.headers, req?.cookies);
+  requestContext.nextUrl = pathname;
+
+  return await asyncLocalStorage.run(requestContext, async () => {
+    log.info({ context: { pathname }, ...requestContext }, "GET NextAuth route");
+
+    const error = searchParams.get("error");
+    if (pathname.includes(NHS_LOGIN_CALLBACK_PATH) && error) {
+      log.error(
+        {
+          error,
+          error_description: searchParams.get("error_description"),
+        },
+        "OAuth provider returned error in callback",
+        requestContext,
+      );
+    }
+    return await handlers.GET(req);
+  });
+};
+
+export const { POST } = handlers;

--- a/src/app/api/sso/route.ts
+++ b/src/app/api/sso/route.ts
@@ -19,6 +19,7 @@ export const GET = async (request: NextRequest) => {
 
   const newSessionId = crypto.randomUUID();
   requestContext.sessionId = newSessionId;
+  requestContext.nextUrl = request.nextUrl.pathname;
 
   await asyncLocalStorage.run(requestContext, async () => {
     log.info("SSO route invoked");

--- a/src/app/check-and-book-vaccinations/page.test.tsx
+++ b/src/app/check-and-book-vaccinations/page.test.tsx
@@ -1,4 +1,5 @@
 import { auth } from "@project/auth";
+import { requestScopedStorageWrapper } from "@project/src/utils/requestScopedStorageWrapper";
 import { useNavigationTransition } from "@src/app/_components/context/NavigationContext";
 import { AgeBasedHubCards } from "@src/app/_components/hub/AgeBasedHubCards";
 import VaccinationsHub from "@src/app/check-and-book-vaccinations/page";
@@ -41,6 +42,10 @@ jest.mock("@src/app/_components/context/NavigationContext", () => ({
   useNavigationTransition: jest.fn(),
 }));
 
+jest.mock("@src/utils/requestScopedStorageWrapper", () => ({
+  requestScopedStorageWrapper: jest.fn().mockImplementation((callback: () => unknown) => callback()),
+}));
+
 (useNavigationTransition as jest.Mock).mockReturnValue({
   navigate: jest.fn(),
   isPending: false,
@@ -57,6 +62,11 @@ const mockSessionDataForAgeGroup = (ageGroup: AgeGroup): Partial<Session> => {
 };
 
 describe("Vaccination Hub Page", () => {
+  it("should wrap the component with requestScopedStorageWrapper", async () => {
+    render(await VaccinationsHub());
+    expect(requestScopedStorageWrapper as jest.Mock).toHaveBeenCalledTimes(1);
+  });
+
   describe("for all ages", () => {
     it.each(Object.entries(AgeGroup))(`renders main heading for %s`, async (ageGroupString, ageGroup) => {
       (auth as jest.Mock).mockResolvedValue(mockSessionDataForAgeGroup(ageGroup));

--- a/src/app/check-and-book-vaccinations/page.tsx
+++ b/src/app/check-and-book-vaccinations/page.tsx
@@ -10,11 +10,16 @@ import BackToNHSAppLink from "@src/app/_components/nhs-app/BackToNHSAppLink";
 import MainContent from "@src/app/_components/nhs-frontend/MainContent";
 import { HUB_FEEDBACK_REFERRER_ID, NHS_TITLE_SUFFIX, SERVICE_HEADING } from "@src/app/constants";
 import { AgeBasedHubDetails, AgeBasedHubInfo, AgeGroup } from "@src/models/ageBasedHub";
+import { requestScopedStorageWrapper } from "@src/utils/requestScopedStorageWrapper";
 import { Session } from "next-auth";
 import { redirect } from "next/navigation";
 import React from "react";
 
 const VaccinationsHub = async () => {
+  return await requestScopedStorageWrapper(VaccinationsHubContent);
+};
+
+const VaccinationsHubContent = async () => {
   const session: Session | null = await auth();
   const ageGroup: AgeGroup = session?.user.age_group as AgeGroup;
   if (ageGroup === AgeGroup.UNKNOWN_AGE_GROUP) {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -29,10 +29,12 @@ function getMockRequest(testUrl: string) {
 
   const cookies: RequestCookies = new RequestCookies(headers).set(SESSION_ID_COOKIE_NAME, "session-id-value");
 
+  const nextUrl = new URL(testUrl);
   return {
     nextUrl: {
-      origin: new URL(testUrl).origin,
-      pathname: new URL(testUrl).pathname,
+      origin: nextUrl.origin,
+      pathname: nextUrl.pathname,
+      href: nextUrl.href,
     },
     url: testUrl,
     headers: headers,
@@ -73,6 +75,16 @@ describe("proxy", () => {
 
     const result = await proxy(mockRequest as NextRequest);
     expect(result.status).toBe(200);
+  });
+
+  it("pass add the nextUrl to the request headers for users with active session", async () => {
+    const testUrl = "https://testurl/abc";
+    const mockRequest = getMockRequest(testUrl);
+
+    (auth as jest.Mock).mockResolvedValue({ user: "test" });
+
+    const result = await proxy(mockRequest as NextRequest);
+    expect(result.headers.get("x-middleware-request-nexturl")).toEqual(testUrl);
   });
 
   it("_getHeadersForLogging() contains map of special headers", async () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -77,7 +77,7 @@ describe("proxy", () => {
     expect(result.status).toBe(200);
   });
 
-  it("pass add the nextUrl to the request headers for users with active session", async () => {
+  it("pass the nextUrl to the request headers for users with active session", async () => {
     const testUrl = "https://testurl/abc";
     const mockRequest = getMockRequest(testUrl);
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -15,6 +15,7 @@ export async function proxy(request: NextRequest) {
   const requestContext: RequestContext = {
     ...extractRequestContextFromHeadersAndCookies(request?.headers, request?.cookies),
     isProxy: true,
+    nextUrl: request.nextUrl.href,
   };
 
   return await asyncLocalStorage.run(requestContext, () => middlewareWrapper(request));
@@ -28,6 +29,8 @@ const middlewareWrapper = async (request: NextRequest) => {
   );
 
   // Add URL and sessionId to request headers to make available for logging in the nodejs layer
+  // context here does not propagate to the nodejs layer, Server Components extract the nextUrl
+  // from the headers using next/headers(), as they do not have access to the full request object
   const headers = new Headers(request.headers);
   headers.set("nextUrl", request.nextUrl.href);
 

--- a/src/utils/auth/callbacks/get-token.test.ts
+++ b/src/utils/auth/callbacks/get-token.test.ts
@@ -8,10 +8,6 @@ import { ConfigMock, configBuilder } from "@test-data/config/builders";
 import { jwtDecode } from "jwt-decode";
 import { Account, Profile } from "next-auth";
 import { JWT } from "next-auth/jwt";
-import { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
-import { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
-import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
-import { cookies, headers } from "next/headers";
 
 jest.mock("@project/auth", () => ({
   auth: jest.fn(),
@@ -19,11 +15,6 @@ jest.mock("@project/auth", () => ({
 
 jest.mock("@src/utils/auth/apim/get-or-refresh-apim-credentials", () => ({
   getOrRefreshApimCredentials: jest.fn(),
-}));
-
-jest.mock("next/headers", () => ({
-  headers: jest.fn(),
-  cookies: jest.fn(),
 }));
 
 jest.mock("jwt-decode");
@@ -63,23 +54,6 @@ describe("getToken", () => {
     jest.clearAllMocks();
     jest.useFakeTimers().setSystemTime(nowInSeconds * 1000);
     process.env.NEXT_RUNTIME = "nodejs";
-
-    const fakeHeaders: ReadonlyHeaders = {
-      get(name: string): string | null {
-        return `fake-${name}-header`;
-      },
-    } as ReadonlyHeaders;
-    (headers as jest.Mock).mockResolvedValue(fakeHeaders);
-
-    const fakeRequestCookies: ReadonlyRequestCookies = {
-      get(name: string): RequestCookie | undefined {
-        return {
-          name: `fake-${name}-name`,
-          value: `fake-${name}-value`,
-        };
-      },
-    } as ReadonlyRequestCookies;
-    (cookies as jest.Mock).mockResolvedValue(fakeRequestCookies);
 
     (jwtDecode as jest.Mock).mockReturnValue({
       jti: "jti_test",

--- a/src/utils/auth/callbacks/get-token.ts
+++ b/src/utils/auth/callbacks/get-token.ts
@@ -5,11 +5,8 @@ import { getOrRefreshApimCredentials } from "@src/utils/auth/apim/get-or-refresh
 import { ApimAccessCredentials } from "@src/utils/auth/apim/types";
 import { BirthDate, IdToken, MaxAgeInSeconds, NowInSeconds } from "@src/utils/auth/types";
 import { logger } from "@src/utils/logger";
-import { RequestContext, asyncLocalStorage } from "@src/utils/requestContext";
-import { extractRequestContextFromHeadersAndCookies } from "@src/utils/requestScopedStorageWrapper";
 import { Account, Profile } from "next-auth";
 import { JWT } from "next-auth/jwt";
-import { cookies, headers } from "next/headers";
 import { Logger } from "pino";
 
 const log: Logger = logger.child({ module: "utils-auth-callbacks-get-token" });
@@ -27,62 +24,55 @@ const getToken = async (
   profile: Profile | undefined,
   maxAgeInSeconds: MaxAgeInSeconds,
 ) => {
-  const headerValues = await headers();
-  const requestCookies = await cookies();
+  if (!token) {
+    log.error("getToken: No token available in jwt callback. Returning null");
+    return null;
+  }
 
-  const requestContext: RequestContext = extractRequestContextFromHeadersAndCookies(headerValues, requestCookies);
+  const nowInSeconds = Math.floor(Date.now() / 1000);
 
-  return await asyncLocalStorage.run(requestContext, async () => {
-    if (!token) {
-      log.error("getToken: No token available in jwt callback. Returning null");
-      return null;
+  // Maximum age reached scenario: invalidate session after fixedExpiry
+  if (token.fixedExpiry && nowInSeconds >= token.fixedExpiry) {
+    log.info("getToken: Token has reached fixedExpiry time, or session has reached the max age. Returning null");
+    return null;
+  }
+
+  let updatedToken: JWT = token;
+
+  // Initial login scenario: account and profile are only defined for the initial login, afterward they become undefined
+  if (isInitialLoginJourney(account, profile) && account != null && profile != null) {
+    updatedToken = updateTokenWithValuesFromAccountAndProfile(
+      token,
+      account,
+      profile,
+      nowInSeconds as NowInSeconds,
+      maxAgeInSeconds,
+    );
+  }
+
+  let apimAccessCredentials = undefined;
+
+  try {
+    // TODO VIA-254 - can we do this only once per request?
+    // every time auth() is called, the getToken() callback is invoked by NextAuth
+    // this results in fetching APIM access token multiple times ( in case it has expired )
+    apimAccessCredentials = await getOrRefreshApimCredentials(token, nowInSeconds);
+  } catch (error) {
+    let errorMessage = undefined;
+    if (error instanceof Error) {
+      errorMessage = error.message;
     }
+    log.error(
+      { context: { errorMessage: errorMessage } },
+      "Error fetching APIM credentials; continuing to create session with empty APIM fields",
+    );
+  }
 
-    const nowInSeconds = Math.floor(Date.now() / 1000);
+  // Inspect the token (which was either returned from login or fetched from session), fill missing or blank values with defaults
+  updatedToken = fillMissingFieldsInTokenWithDefaultValues(updatedToken, apimAccessCredentials);
 
-    // Maximum age reached scenario: invalidate session after fixedExpiry
-    if (token.fixedExpiry && nowInSeconds >= token.fixedExpiry) {
-      log.info("getToken: Token has reached fixedExpiry time, or session has reached the max age. Returning null");
-      return null;
-    }
-
-    let updatedToken: JWT = token;
-
-    // Initial login scenario: account and profile are only defined for the initial login, afterward they become undefined
-    if (isInitialLoginJourney(account, profile) && account != null && profile != null) {
-      updatedToken = updateTokenWithValuesFromAccountAndProfile(
-        token,
-        account,
-        profile,
-        nowInSeconds as NowInSeconds,
-        maxAgeInSeconds,
-      );
-    }
-
-    let apimAccessCredentials = undefined;
-
-    try {
-      // TODO VIA-254 - can we do this only once per request?
-      // every time auth() is called, the getToken() callback is invoked by NextAuth
-      // this results in fetching APIM access token multiple times ( in case it has expired )
-      apimAccessCredentials = await getOrRefreshApimCredentials(token, nowInSeconds);
-    } catch (error) {
-      let errorMessage = undefined;
-      if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      log.error(
-        { context: { errorMessage: errorMessage } },
-        "Error fetching APIM credentials; continuing to create session with empty APIM fields",
-      );
-    }
-
-    // Inspect the token (which was either returned from login or fetched from session), fill missing or blank values with defaults
-    updatedToken = fillMissingFieldsInTokenWithDefaultValues(updatedToken, apimAccessCredentials);
-
-    log.debug({ context: { updatedToken } }, "Returning JWT from callback");
-    return updatedToken;
-  });
+  log.debug({ context: { updatedToken } }, "Returning JWT from callback");
+  return updatedToken;
 };
 
 const fillMissingFieldsInTokenWithDefaultValues = (token: JWT, apimAccessCredentials?: ApimAccessCredentials): JWT => {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Extra logging added as part of this story

- Presence of nonce cookie (true/false) in nextAuth error logs
- Log  saying "GET /api/auth/..." for next auth endpoints listed in the story
- nextUrl added to logging context in "/api/sso" and "/api/auth/..." endpoints listed in the story
- where nextUrl has been added to a new endpoint it appears as the pathname only without any url params eg /api/auth/session
- existing endpoints log out the whole url including params - this is existing behaviour
- When an OAuthCallbackError is encountered an error log with the error and description
- the error and description are fields passed to us by NHS Login as url params to our callback url and are safe to log, containing no PII 


## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
